### PR TITLE
README: adopt the sibling SDKs' full-logo hero, BEAM stack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 [![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-support-ea4aaa.svg?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/rgfaber)
 
 <p align="center">
-  <img src="assets/logo.svg" width="120" height="120" alt="Macula">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/macula-full-dark.svg">
+    <img src="assets/macula-full-light.svg" alt="Macula" width="320">
+  </picture>
 </p>
 
 <p align="center">

--- a/assets/macula-full-dark.svg
+++ b/assets/macula-full-dark.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Macula full logo, BEAM badge (dark theme) — same mesh as the
+     macula-*-sdk, macula-mcp, and macula-lazymesh logos. Badge glyph is
+     three small nodes in a cluster (not a specific project's mascot —
+     BEAM covers Erlang, Elixir, Gleam and others), echoing the mesh
+     icon's own node vocabulary and standing for BEAM's defining trait:
+     many lightweight, isolated processes. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 88" width="240" height="88">
+  <!-- Icon -->
+  <g transform="translate(4, 12) scale(0.64)">
+    <!-- Subtle grid -->
+    <g stroke="#38BDF8" stroke-width="0.5" opacity="0.08">
+      <line x1="0" y1="25" x2="100" y2="25"/>
+      <line x1="0" y1="50" x2="100" y2="50"/>
+      <line x1="0" y1="75" x2="100" y2="75"/>
+      <line x1="25" y1="0" x2="25" y2="100"/>
+      <line x1="50" y1="0" x2="50" y2="100"/>
+      <line x1="75" y1="0" x2="75" y2="100"/>
+    </g>
+
+    <!-- Irregular mesh connections -->
+    <g stroke="#38BDF8" stroke-width="1.5" fill="none">
+      <line x1="22" y1="20" x2="50" y2="32"/>
+      <line x1="50" y1="32" x2="78" y2="18"/>
+      <line x1="22" y1="20" x2="15" y2="52"/>
+      <line x1="78" y1="18" x2="85" y2="45"/>
+      <line x1="15" y1="52" x2="35" y2="55"/>
+      <line x1="35" y1="55" x2="50" y2="50"/>
+      <line x1="50" y1="50" x2="68" y2="48"/>
+      <line x1="68" y1="48" x2="85" y2="45"/>
+      <line x1="15" y1="52" x2="28" y2="80"/>
+      <line x1="35" y1="55" x2="50" y2="78"/>
+      <line x1="50" y1="50" x2="50" y2="78"/>
+      <line x1="68" y1="48" x2="72" y2="75"/>
+      <line x1="85" y1="45" x2="72" y2="75"/>
+      <line x1="28" y1="80" x2="50" y2="78"/>
+      <line x1="50" y1="78" x2="72" y2="75"/>
+      <line x1="22" y1="20" x2="35" y2="55" stroke-dasharray="3,2" opacity="0.5"/>
+      <line x1="78" y1="18" x2="68" y2="48" stroke-dasharray="3,2" opacity="0.5"/>
+      <line x1="50" y1="32" x2="50" y2="50" stroke-dasharray="3,2" opacity="0.5"/>
+    </g>
+
+    <!-- Orange accents -->
+    <g stroke="#FB923C" stroke-width="2" fill="none">
+      <line x1="35" y1="55" x2="68" y2="48"/>
+      <line x1="50" y1="32" x2="35" y2="55" stroke-dasharray="4,3"/>
+    </g>
+
+    <!-- Primary nodes -->
+    <g stroke="#38BDF8" stroke-width="2" fill="#1E293B">
+      <circle cx="22" cy="20" r="4"/>
+      <circle cx="78" cy="18" r="4"/>
+      <circle cx="15" cy="52" r="3"/>
+      <circle cx="85" cy="45" r="3"/>
+      <circle cx="28" cy="80" r="4"/>
+      <circle cx="72" cy="75" r="4"/>
+    </g>
+
+    <!-- Hub nodes -->
+    <g stroke="#38BDF8" stroke-width="2" fill="#F8FAFC">
+      <circle cx="50" cy="32" r="4"/>
+      <circle cx="50" cy="78" r="4"/>
+    </g>
+
+    <!-- Central hub -->
+    <circle cx="50" cy="50" r="7" stroke="#38BDF8" stroke-width="2" fill="#1E293B"/>
+    <circle cx="50" cy="50" r="3.5" fill="#38BDF8"/>
+
+    <!-- Secondary nodes -->
+    <g stroke="#38BDF8" stroke-width="1.5" fill="#1E293B">
+      <circle cx="35" cy="55" r="3"/>
+      <circle cx="68" cy="48" r="3"/>
+    </g>
+    <g fill="#FB923C">
+      <circle cx="35" cy="55" r="1.5"/>
+      <circle cx="68" cy="48" r="1.5"/>
+    </g>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="76" y="46"
+        font-family="'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace"
+        font-size="30"
+        font-weight="600"
+        fill="#38BDF8"
+        letter-spacing="-0.5px">MACULA</text>
+  <text x="77" y="68"
+        font-family="'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace"
+        font-size="15"
+        font-weight="500"
+        fill="#FB923C"
+        letter-spacing="3px">BEAM</text>
+
+  <!-- BEAM badge: styled as a large hub node, matching the mesh's own
+       vocabulary. Glyph is a small cluster of three nodes, standing for
+       many lightweight isolated processes, not any single project's
+       mascot, since BEAM spans Erlang, Elixir, Gleam and others. -->
+  <circle cx="54" cy="66" r="13" fill="#1E293B" stroke="#38BDF8" stroke-width="2"/>
+  <g fill="#38BDF8">
+    <circle cx="54" cy="60" r="2.4"/>
+    <circle cx="49" cy="70" r="2.4"/>
+    <circle cx="59" cy="70" r="2.4"/>
+  </g>
+  <g stroke="#38BDF8" stroke-width="1.1" fill="none">
+    <line x1="54" y1="60" x2="49" y2="70"/>
+    <line x1="54" y1="60" x2="59" y2="70"/>
+    <line x1="49" y1="70" x2="59" y2="70"/>
+  </g>
+</svg>

--- a/assets/macula-full-light.svg
+++ b/assets/macula-full-light.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Macula full logo, BEAM badge (light theme) — see macula-full-dark.svg
+     for the badge glyph rationale. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 88" width="240" height="88">
+  <!-- Icon -->
+  <g transform="translate(4, 12) scale(0.64)">
+    <!-- Subtle grid -->
+    <g stroke="#1E3A5F" stroke-width="0.5" opacity="0.1">
+      <line x1="0" y1="25" x2="100" y2="25"/>
+      <line x1="0" y1="50" x2="100" y2="50"/>
+      <line x1="0" y1="75" x2="100" y2="75"/>
+      <line x1="25" y1="0" x2="25" y2="100"/>
+      <line x1="50" y1="0" x2="50" y2="100"/>
+      <line x1="75" y1="0" x2="75" y2="100"/>
+    </g>
+
+    <!-- Irregular mesh connections -->
+    <g stroke="#0EA5E9" stroke-width="1.5" fill="none">
+      <line x1="22" y1="20" x2="50" y2="32"/>
+      <line x1="50" y1="32" x2="78" y2="18"/>
+      <line x1="22" y1="20" x2="15" y2="52"/>
+      <line x1="78" y1="18" x2="85" y2="45"/>
+      <line x1="15" y1="52" x2="35" y2="55"/>
+      <line x1="35" y1="55" x2="50" y2="50"/>
+      <line x1="50" y1="50" x2="68" y2="48"/>
+      <line x1="68" y1="48" x2="85" y2="45"/>
+      <line x1="15" y1="52" x2="28" y2="80"/>
+      <line x1="35" y1="55" x2="50" y2="78"/>
+      <line x1="50" y1="50" x2="50" y2="78"/>
+      <line x1="68" y1="48" x2="72" y2="75"/>
+      <line x1="85" y1="45" x2="72" y2="75"/>
+      <line x1="28" y1="80" x2="50" y2="78"/>
+      <line x1="50" y1="78" x2="72" y2="75"/>
+      <line x1="22" y1="20" x2="35" y2="55" stroke-dasharray="3,2" opacity="0.6"/>
+      <line x1="78" y1="18" x2="68" y2="48" stroke-dasharray="3,2" opacity="0.6"/>
+      <line x1="50" y1="32" x2="50" y2="50" stroke-dasharray="3,2" opacity="0.6"/>
+    </g>
+
+    <!-- Orange accents -->
+    <g stroke="#F97316" stroke-width="2" fill="none" opacity="0.9">
+      <line x1="35" y1="55" x2="68" y2="48"/>
+      <line x1="50" y1="32" x2="35" y2="55" stroke-dasharray="4,3"/>
+    </g>
+
+    <!-- Primary nodes -->
+    <g stroke="#0EA5E9" stroke-width="2" fill="#0C1929">
+      <circle cx="22" cy="20" r="4"/>
+      <circle cx="78" cy="18" r="4"/>
+      <circle cx="15" cy="52" r="3"/>
+      <circle cx="85" cy="45" r="3"/>
+      <circle cx="28" cy="80" r="4"/>
+      <circle cx="72" cy="75" r="4"/>
+    </g>
+
+    <!-- Hub nodes - white -->
+    <g stroke="#0EA5E9" stroke-width="2" fill="white">
+      <circle cx="50" cy="32" r="4"/>
+      <circle cx="50" cy="78" r="4"/>
+    </g>
+
+    <!-- Central hub -->
+    <circle cx="50" cy="50" r="7" stroke="#0EA5E9" stroke-width="2" fill="#0C1929"/>
+    <circle cx="50" cy="50" r="3.5" fill="#0EA5E9"/>
+
+    <!-- Secondary nodes -->
+    <g stroke="#0EA5E9" stroke-width="1.5" fill="#0C1929">
+      <circle cx="35" cy="55" r="3"/>
+      <circle cx="68" cy="48" r="3"/>
+    </g>
+    <g fill="#F97316">
+      <circle cx="35" cy="55" r="1.5"/>
+      <circle cx="68" cy="48" r="1.5"/>
+    </g>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="76" y="46"
+        font-family="'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace"
+        font-size="30"
+        font-weight="600"
+        fill="#0EA5E9"
+        letter-spacing="-0.5px">MACULA</text>
+  <text x="77" y="68"
+        font-family="'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace"
+        font-size="15"
+        font-weight="500"
+        fill="#F97316"
+        letter-spacing="3px">BEAM</text>
+
+  <!-- BEAM badge: styled as a large hub node, matching the mesh's own
+       vocabulary. Glyph is a small cluster of three nodes, standing for
+       many lightweight isolated processes, not any single project's
+       mascot, since BEAM spans Erlang, Elixir, Gleam and others. -->
+  <circle cx="54" cy="66" r="13" fill="#F8FAFC" stroke="#0EA5E9" stroke-width="2"/>
+  <g fill="#0EA5E9">
+    <circle cx="54" cy="60" r="2.4"/>
+    <circle cx="49" cy="70" r="2.4"/>
+    <circle cx="59" cy="70" r="2.4"/>
+  </g>
+  <g stroke="#0EA5E9" stroke-width="1.1" fill="none">
+    <line x1="54" y1="60" x2="49" y2="70"/>
+    <line x1="54" y1="60" x2="59" y2="70"/>
+    <line x1="49" y1="70" x2="59" y2="70"/>
+  </g>
+</svg>


### PR DESCRIPTION
Raf's direction: this repo's README should mirror the layout and artwork of the sibling SDKs (macula-go/rust/php/dotnet/py/ts) and macula-mcp/lazymesh -- the full mesh-icon + MACULA wordmark + stack-name sub-label + badge circle, not the old plain square logo.svg.

## What changed

New `assets/macula-full-{dark,light}.svg`, built from the exact same mesh icon graphic every sibling repo uses (same coordinates, same grid, same node layout), with:
- wordmark sub-label "BEAM" (Raf's chosen label) instead of a single language name, since this repo is the Erlang/OTP client but the protocol itself is shared across the BEAM family (Erlang, Elixir, Gleam)
- badge glyph: a small cluster of three connected nodes, not any one project's mascot (unlike e.g. macula-go's real gopher badge) -- BEAM isn't a single project with one owner, and the node-cluster glyph reuses the mesh icon's own visual vocabulary while standing for BEAM's actual defining trait: many lightweight isolated processes

README.md's hero now uses the same `<picture>` dark/light-source pattern every sibling README already uses. The old `assets/logo.svg` is left in place (not deleted, no longer referenced anywhere) in case it's wanted for something else, like a repo avatar, that a wide wordmark banner doesn't serve.

## Test plan

- [x] Both new SVGs validated as well-formed XML (caught and fixed a double-hyphen inside an XML comment, invalid syntax, before committing)
- [x] Confirmed `assets/logo.svg` isn't referenced anywhere else in the repo before leaving it in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UHwKHzxzFiRA2XnLUUzGC
